### PR TITLE
Add Config.toml to version control to fix GitHub workflows build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ generated/
 .DS_Store
 *Ballerina.lock
 .ballerina
-**/Config.toml
+# **/Config.toml
 
 # Ignore Gradle project-specific cache directory
 .gradle

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ generated/
 .DS_Store
 *Ballerina.lock
 .ballerina
-# **/Config.toml
+**/Config.toml
 
 # Ignore Gradle project-specific cache directory
 .gradle

--- a/ballerina/tests/Config.toml
+++ b/ballerina/tests/Config.toml
@@ -1,0 +1,4 @@
+isLiveServer = false
+clientId = "string"
+clientSecret = "string"
+refreshToken = "string"


### PR DESCRIPTION
## Purpose
Add Config.toml to version control to ensure GitHub workflows can access necessary configuration during builds.

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility