### PR TITLE
Remove Config.toml from Ballerina directory and add default values for configurable variables

### DIFF
--- a/ballerina/tests/Config.toml
+++ b/ballerina/tests/Config.toml
@@ -1,4 +1,0 @@
-isLiveServer = false
-clientId = "string"
-clientSecret = "string"
-refreshToken = "string"

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -18,10 +18,10 @@ import ballerina/http;
 import ballerina/oauth2;
 import ballerina/test;
 
-configurable boolean isLiveServer = ?;
-configurable string clientId = ?;
-configurable string clientSecret = ?;
-configurable string refreshToken = ?;
+configurable boolean isLiveServer = false;
+configurable string clientId = "clientId";
+configurable string clientSecret = "clientSecret";
+configurable string refreshToken = "refreshToken";
 
 final string serviceUrl = isLiveServer ? "https://api.hubapi.com/crm/v3/objects/calls" : "http://localhost:9090";
 final Client hubSpotClient = check initClient();


### PR DESCRIPTION
## Purpose
To remove the Config.toml and default values for the configurable variables in test.bal

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
